### PR TITLE
Set port using the API

### DIFF
--- a/autoload/scnvim/sclang.vim
+++ b/autoload/scnvim/sclang.vim
@@ -59,7 +59,7 @@ function! scnvim#sclang#initialize_remote_plugin() abort
     return
   endif
   let port = get(g:, 'scnvim_udp_port', 9670)
-  let g:scnvim_python_port = __scnvim_server_start(port)
+  call __scnvim_server_start(port)
 endfunction
 
 " job handlers

--- a/rplugin/python3/scnvim/scnvim.py
+++ b/rplugin/python3/scnvim/scnvim.py
@@ -89,6 +89,8 @@ class SCNvim():
         self.port = port
         thread = Thread(target=self.server_loop)
         thread.start()
+        # fix for pynvim 0.4
+        self.nvim.api.set_var('scnvim_python_port', port)
         return port
 
     @pynvim.autocmd('VimLeavePre', pattern='*', sync=True)


### PR DESCRIPTION
Problem: The __scnvim_server_start function does not seem to return a value starting
from pynvim 0.4.

Solution: Set the g: variable using the API instead.