### PR TITLE
Don't display function signature for ambivalent methods

### DIFF
--- a/sc/Classes/SCNvimDoc/extSCNvim.sc
+++ b/sc/Classes/SCNvimDoc/extSCNvim.sc
@@ -3,8 +3,14 @@
         var args, message;
         try {
             args = Help.methodArgs(method);
-            message = (action: "method_args", args: args);
-            SCNvim.sendJSON(message);
+            // TODO;
+            // this is just a quick fix.
+            // how should we handle methods implemented by many classes?
+            args = args.split(Char.nl);
+            if (args.size == 1) {
+                message = (action: "method_args", args: args[0]);
+                SCNvim.sendJSON(message);
+            }
         } {
             ^"[scnvim] Could not find args for %".format(method);
         }


### PR DESCRIPTION
This is just a quickfix until we have a better parser.