### PR TITLE
Fix linux path errors in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,13 @@ This directory needs to be linked to your SuperCollider `Extensions` directory (
 
     ```shell
     # create scide_scvim directory
-    mkdir -p ~/Library/Application\ Support/SuperCollider/Extensions/scide_scvim
-
+    mkdir -p $HOME/.local/share/SuperCollider/Extensions/scide_scvim
+    
     # create a symbolic link to 'sc' in the 'scide_scvim' directory named 'scnvim'
-    ln -s /home/<USER>/.vim/plugged/scnvim/sc /home/<user>/.local/SuperCollider/Extensions/scide_scvim
+    ln -s /home/<USER>/.vim/plugged/scnvim/sc /home/<user>/.local/share/SuperCollider/Extensions/scide_scvim
     ```
-
+    
+    If the above symlink does not work (you can tell this by opening up a SuperCollider file and running `:SCNvimStart` - if something's wrong the post window will contain errors about SC not being able to find the SCNvim class files), make sure the path to the vim plugin is correct. On some NeoVim installations it's `/home/<USER>/.config/nvim/plugged/scnvim/sc`.
 
 #### 3. Starting SCNvim
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This directory needs to be linked to your SuperCollider `Extensions` directory (
     mkdir -p ~/Library/Application\ Support/SuperCollider/Extensions/scide_scvim
 
     # create a symbolic link to 'sc' in the 'scide_scvim' directory named 'scnvim'
-    ln -s <ABSOLUTE_PATH_TO_SCNVIM_PLUGIN>/sc ~/Library/Application\ Support/SuperCollider/Extensions/scide_scvim/scnvim
+    ln -s ~/.config/nvim/plugged/scnvim/sc ~/Library/Application\ Support/SuperCollider/Extensions/scide_scvim/scnvim
     ```
 
 * **Linux**
@@ -114,10 +114,14 @@ This directory needs to be linked to your SuperCollider `Extensions` directory (
     mkdir -p $HOME/.local/share/SuperCollider/Extensions/scide_scvim
     
     # create a symbolic link to 'sc' in the 'scide_scvim' directory named 'scnvim'
-    ln -s /home/<USER>/.vim/plugged/scnvim/sc /home/<user>/.local/share/SuperCollider/Extensions/scide_scvim
+    ln -s /home/<USER>/.config/nvim/plugged/scnvim/sc /home/<USER>/.local/share/SuperCollider/Extensions/scide_scvim
     ```
-    
-    If the above symlink does not work (you can tell this by opening up a SuperCollider file and running `:SCNvimStart` - if something's wrong the post window will contain errors about SC not being able to find the SCNvim class files), make sure the path to the vim plugin is correct. On some NeoVim installations it's `/home/<USER>/.config/nvim/plugged/scnvim/sc`.
+
+    If the above symlink does not work (you can tell this by opening up a
+    SuperCollider file and running `:SCNvimStart` - if something's wrong the
+    post window will contain errors about SC not being able to find the SCNvim
+    class files), make sure the path to the vim plugin is correct. Depending on
+    how you have configured nvim, it might be `/home/<USER>/.vim/plugged/scnvim/sc`.
 
 #### 3. Starting SCNvim
 


### PR DESCRIPTION
The readme contains errors in the section on symlinking. This should fix it. 

We need a more consistent way of making sure the symlinks are correct (by somehow verifying that the source path and destination path in the command actually exist before running the symlink command)