### PR TITLE
[WIP] Add install scripts for supported platforms

### DIFF
--- a/bin/install_linux.sh
+++ b/bin/install_linux.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-dest_dir=$HOME/Library/Application\ Support/SuperCollider/Extensions/scide_scvim
+dest_dir=$HOME/.local/share/SuperCollider/Extensions/scide_scvim
 ./install_unix.sh "$dest_dir"

--- a/bin/install_linux.sh
+++ b/bin/install_linux.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+dest_dir=$HOME/Library/Application\ Support/SuperCollider/Extensions/scide_scvim
+./install_unix.sh "$dest_dir"

--- a/bin/install_linux.sh
+++ b/bin/install_linux.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 dest_dir=$HOME/.local/share/SuperCollider/Extensions/scide_scvim
-./install_unix.sh "$dest_dir"
+$(pwd)/bin/install_unix.sh "$dest_dir"

--- a/bin/install_mac.sh
+++ b/bin/install_mac.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+dest_dir=$HOME/Library/Application\ Support/SuperCollider/Extensions/scide_scvim
+./install_unix.sh "$dest_dir"

--- a/bin/install_mac.sh
+++ b/bin/install_mac.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 dest_dir=$HOME/Library/Application\ Support/SuperCollider/Extensions/scide_scvim
-./install_unix.sh "$dest_dir"
+$(pwd)/bin/install_unix.sh "$dest_dir"

--- a/bin/install_unix.sh
+++ b/bin/install_unix.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+plugin_dir=$(dirname "$(pwd)")
+dest_dir="$1"
+
+# if destination is a symbolic link (old install instructions)
+if [ -L "$dest_dir" ]; then
+  echo "$dest_dir" already exists! Delete it and run this script again.
+fi
+
+mkdir -p "$dest_dir"
+[ ! -e "$dest_dir/scnvim" ] && ln -s "$plugin_dir/sc" "$dest_dir/scnvim"

--- a/bin/install_unix.sh
+++ b/bin/install_unix.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-plugin_dir=$(dirname "$(pwd)")
+plugin_dir="$(pwd)"
 dest_dir="$1"
 
 # if destination is a symbolic link (old install instructions)

--- a/bin/install_unix.sh
+++ b/bin/install_unix.sh
@@ -6,7 +6,12 @@ dest_dir="$1"
 # if destination is a symbolic link (old install instructions)
 if [ -L "$dest_dir" ]; then
   echo "$dest_dir" already exists! Delete it and run this script again.
+  exit 1
 fi
 
 mkdir -p "$dest_dir"
-[ ! -e "$dest_dir/scnvim" ] && ln -s "$plugin_dir/sc" "$dest_dir/scnvim"
+if [ ! -e "$dest_dir/scnvim" ]; then
+  ln -s "$plugin_dir/sc" "$dest_dir/scnvim"
+fi
+
+exit 0


### PR DESCRIPTION
## Update

**I'm rewriting this as lua module now, so please refrain from testing this PR. Will push an alternative soon.**

Add automated install scripts for all supported platforms. This will make installation of this plugin much easier, since the script can be called from a package manager such as `vim-plug`.

The install script will abort with a warning if it detects the "old" recommended way of installing this plugin (e.g. creating a symlink named `scide_scvim`). The user is then prompted to delete it manually and run the script again.

Example usage with vim-plug:

```vim
Plug 'davidgranstrom/scnvim', { 'do': './bin/install_mac.sh' }
```

**Scripts**

- [x] macOS
- [x] linux
- [ ] windows

**Tested**

- [x] macOS
- [ ] linux
- [ ] windows
