### PR TITLE
Improve exit handling

### DIFF
--- a/autoload/scnvim/lua.vim
+++ b/autoload/scnvim/lua.vim
@@ -4,12 +4,10 @@
 
 scriptencoding utf-8
 
-autocmd scnvim VimLeavePre * call scnvim#lua#deinit()
-
 function! scnvim#lua#init() abort
-  call luaeval('require("scnvim").init()')
+  lua require('scnvim').init()
 endfunction
 
 function! scnvim#lua#deinit() abort
-  call luaeval('require("scnvim").deinit()')
+  lua require('scnvim').deinit()
 endfunction

--- a/autoload/scnvim/sclang.vim
+++ b/autoload/scnvim/sclang.vim
@@ -86,9 +86,6 @@ endfunction
 
 let s:chunks = ['']
 function! s:Sclang.on_stdout(id, data, event) dict abort
-  if s:is_exiting
-    return
-  endif
   let s:chunks[-1] .= a:data[0]
   call extend(s:chunks, a:data[1:])
   for line in s:chunks
@@ -116,6 +113,9 @@ function! s:send(cmd) abort
 endfunction
 
 function! s:receive(self, data) abort
+  if s:is_exiting
+    return
+  endif
   let bufnr = get(a:self, 'bufnr')
   let winnr = bufwinid(bufnr)
   " scan for ERROR: marker in sclang stdout

--- a/lua/scnvim.lua
+++ b/lua/scnvim.lua
@@ -60,6 +60,7 @@ local function on_receive(err, chunk)
 end
 
 --- Public interface
+
 function scnvim.init()
   udp.start_server(on_receive)
 end
@@ -69,9 +70,13 @@ function scnvim.deinit()
 end
 
 function scnvim.eval(expr, cb)
-  local cmd = string.format('SCNvim.eval("%s");', pesc(expr))
+  local cmd = string.format('SCNvim.eval("%s");', expr)
   eval_callback = cb
   utils.send_to_sc(cmd)
+end
+
+function scnvim.send(expr)
+  utils.send_to_sc(expr)
 end
 
 return scnvim

--- a/lua/udp.lua
+++ b/lua/udp.lua
@@ -21,7 +21,9 @@ end
 
 function M.stop_server()
   if M.udp then
+    M.udp:recv_stop()
     M.udp:close()
+    M.udp = nil
   end
 end
 

--- a/plugin/supercollider.vim
+++ b/plugin/supercollider.vim
@@ -19,6 +19,7 @@ augroup END
 
 autocmd scnvim ColorScheme * highlight default SCNvimEval guifg=black guibg=white ctermfg=black ctermbg=white
 autocmd scnvim BufEnter,BufNewFile,BufRead *.scd,*.sc call scnvim#document#set_current_path()
+autocmd scnvim VimLeavePre * call scnvim#sclang#close()
 
 " eval flash default color
 highlight default SCNvimEval guifg=black guibg=white ctermfg=black ctermbg=white

--- a/plugin/supercollider.vim
+++ b/plugin/supercollider.vim
@@ -19,7 +19,6 @@ augroup END
 
 autocmd scnvim ColorScheme * highlight default SCNvimEval guifg=black guibg=white ctermfg=black ctermbg=white
 autocmd scnvim BufEnter,BufNewFile,BufRead *.scd,*.sc call scnvim#document#set_current_path()
-autocmd scnvim VimLeavePre * call scnvim#sclang#close()
 
 " eval flash default color
 highlight default SCNvimEval guifg=black guibg=white ctermfg=black ctermbg=white

--- a/sc/Classes/SCNvim.sc
+++ b/sc/Classes/SCNvim.sc
@@ -16,6 +16,12 @@ SCNvim {
         }
     }
 
+    *eval {|expr|
+        var result = expr.interpret;
+        result = (action: "eval", args: result);
+        SCNvim.sendJSON(result);
+    }
+
     *updateStatusLine {arg interval=1;
         var stlFunc = {
             var serverStatus, levelMeter, data;

--- a/syntax/supercollider.vim
+++ b/syntax/supercollider.vim
@@ -24,6 +24,8 @@
 " Version:	0.3
 " Modified:	2018-01-06
 
+scriptencoding utf-8
+
 if exists('b:current_syntax')
   finish
 endif


### PR DESCRIPTION
Exit sclang by sending `0.exit` instead of just stopping the job directly. This let's sclang do some internal cleanup, e.g. any current recordings started with `s.record` will be finialized before exiting.

Closes #80 