### PR TITLE
Be able to use a custom render program for SCDoc

### DIFF
--- a/autoload/health/scnvim.vim
+++ b/autoload/health/scnvim.vim
@@ -41,19 +41,23 @@ function! s:check_sclang_executable() abort
   endtry
 endfunction
 
-function! s:check_pandoc_executable() abort
-  let user_pandoc = get(g:, 'scnvim_pandoc_executable')
-  if !empty(user_pandoc)
-    call health#report_info('using g:scnvim_pandoc_executable = ' . user_pandoc)
+function! s:check_scdoc_render_prg() abort
+  let scdoc_prg = get(g:, 'scnvim_scdoc_render_prg')
+  if !empty(scdoc_prg)
+    call health#report_info('using g:scnvim_scdoc_render_prg = ' . scdoc_prg)
   endif
+  let scdoc_args = scnvim#util#get_scdoc_render_args()
+  if !empty(scdoc_args)
+    call health#report_info('using g:scnvim_scdoc_render_args = ' . scdoc_args)
+  endif
+  " default
   try
-    let pandoc = scnvim#util#find_pandoc_executable()
-    call health#report_info('pandoc executable: ' . pandoc)
+    let exe = scnvim#util#find_scdoc_render_prg()
+    call health#report_info('scdoc render program: ' . exe)
   catch
     call health#report_info(
-          \ 'could not find pandoc executable.',
-          \ 'set g:scnvim_pandoc_executable or add pandoc to your $PATH',
-          \ 'This is an optional dependency and only needed for SCDoc integration.'
+          \ 'Could not find scdoc render program. See :h scnvim-help-system for more information.
+          \  This is an optional dependency and only needed for SCDoc integration.'
           \ )
   endtry
 endfunction
@@ -63,5 +67,5 @@ function! health#scnvim#check() abort
   call s:check_minimum_nvim_version()
   call s:check_timers()
   call s:check_sclang_executable()
-  call s:check_pandoc_executable()
+  call s:check_scdoc_render_prg()
 endfunction

--- a/autoload/scnvim/help.vim
+++ b/autoload/scnvim/help.vim
@@ -8,13 +8,13 @@ function! scnvim#help#open_help_for(subject) abort
   let internal = get(g:, 'scnvim_scdoc', 0)
   if internal
     let settings = scnvim#util#get_user_settings()
-    let pandoc_path = settings.paths.pandoc_executable 
-    let has_pandoc = !empty(pandoc_path)
-    if has_pandoc
-      let cmd = printf('SCNvim.openHelpFor("%s", "", "%s");',
-            \ a:subject, pandoc_path)
+    let scdoc_renderer = settings.paths.scdoc_render_prg
+    let scdoc_render_args = scnvim#util#get_scdoc_render_args()
+    if !empty(scdoc_renderer)
+      let cmd = printf('SCNvim.openHelpFor("%s", "", "%s", "%s");',
+            \ a:subject, scdoc_renderer, scdoc_render_args)
     else
-      call scnvim#util#err('Could not find pandoc executable.')
+      call scnvim#util#err('Could not find g:scnvim_scdoc_render_prg')
     endif
   else
     let cmd = printf('HelpBrowser.openHelpFor("%s");', a:subject)
@@ -57,13 +57,13 @@ endfunction
 
 function! scnvim#help#render(uri, pattern) abort
   let settings = scnvim#util#get_user_settings()
-  let pandoc_path = settings.paths.pandoc_executable
-  let has_pandoc = !empty(pandoc_path)
-  if has_pandoc
-    let cmd = printf("SCNvim.renderMethod(\"%s\", \"%s\", \"%s\")",
-          \ a:uri, a:pattern, pandoc_path)
+  let scdoc_renderer = settings.paths.scdoc_render_prg
+  let scdoc_render_args = scnvim#util#get_scdoc_render_args()
+  if !empty(scdoc_renderer)
+    let cmd = printf('SCNvim.renderMethod("%s", "%s", "%s", "%s")',
+          \ a:uri, a:pattern, scdoc_renderer, scdoc_render_args)
     call scnvim#sclang#send_silent(cmd)
   else
-    call scnvim#util#err('Could not find pandoc executable.')
+    call scnvim#util#err('Could not find g:scnvim_scdoc_render_prg')
   endif
 endfunction

--- a/autoload/scnvim/util.vim
+++ b/autoload/scnvim/util.vim
@@ -68,17 +68,22 @@ function! scnvim#util#find_sclang_executable() abort
   throw 'could not find sclang exeutable'
 endfunction
 
-function! scnvim#util#find_pandoc_executable() abort
-  let exe = get(g:, 'scnvim_pandoc_executable', '')
+function! scnvim#util#find_scdoc_render_prg() abort
+  let exe = get(g:, 'scnvim_scdoc_render_prg', '')
   if !empty(exe)
     " user defined
     return expand(exe)
   elseif !empty(exepath('pandoc'))
-    " in $PATH
+    " default
     return exepath('pandoc')
   else
     return ''
   endif
+endfunction
+
+function! scnvim#util#get_scdoc_render_args() abort
+  " default render args
+  return get(g:, 'scnvim_scdoc_render_args', '% --from html --to plain -o %')
 endfunction
 
 function! scnvim#util#generate_tags() abort
@@ -147,10 +152,10 @@ function! scnvim#util#get_user_settings() abort
         \ }
 
   let sclang_executable = scnvim#util#find_sclang_executable()
-  let pandoc_executable = scnvim#util#find_pandoc_executable()
+  let scdoc_render_prg = scnvim#util#find_scdoc_render_prg()
   let paths = {
         \ 'sclang_executable': sclang_executable,
-        \ 'pandoc_executable': pandoc_executable,
+        \ 'scdoc_render_prg': scdoc_render_prg,
         \ }
 
   let settings = {

--- a/doc/SCNvim.txt
+++ b/doc/SCNvim.txt
@@ -134,10 +134,9 @@ HELP SYSTEM                                                 *scnvim-help-system*
 SCNvim can be configured to render SCDoc help files (.schelp) to plain text
 and display the result in a split window, much like Nvim's default help system.
 
-The scnvim help system uses `pandoc` to convert the HTML help file into plain
-text with some additional vim-help markup. Pandoc is therefor a dependency for
-this feature, it is available for download in most package managers. See the
-pandoc homepage[1] for more information.
+The scnvim help system needs a program to convert HTML help files into plain
+text. By default it looks for `pandoc`[1], so it should be enough to have `pandoc`
+accessible in your `$PATH`.
 
 Set the global variable `g:scnvim_scdoc` in your `init.vim` to enable the
 help system.
@@ -157,6 +156,25 @@ more about how the 'quickfix' window works.
 To see an overview (outline) of the content of the help file press `gO`. This
 will open a window local quickfix window (a 'location-list'), use this list to
 jump to different sections of the document.
+
+Customization ~
+
+If you want to use another program as html to plain text converter, or if you
+have `pandoc` installed but not accessible in your `$PATH` you can set
+`g:scnvim_scdoc_render_prg` to point to an executable of your choice. If you
+are not using `pandoc` you will also need to supply an argument string which
+will be used for file input and output. The default format string is:
+>
+  let g:scnvim_scdoc_render_args = '% --from html --to plain -o %'
+<
+Note the two sclang format symbols ('%'), the first '%' represents the input file
+(html) and the second one is the output file (txt).
+
+A complete custom example using `html2text`:
+>
+  let g:scnvim_scdoc_render_prg = '/usr/local/bin/html2text'
+  let g:scnvim_scdoc_render_args = '% -o %'
+<
 
 [1]: https://pandoc.org/
 

--- a/plugin/supercollider.vim
+++ b/plugin/supercollider.vim
@@ -39,3 +39,11 @@ if exists('g:scnvim_udp_port')
         \ in SuperCollider.'
   echohl None
 endif
+
+if exists('g:scnvim_pandoc_executable')
+  echohl WarningMsg
+  echom '[scnvim] g:scnvim_pandoc_executable is deprecated.
+        \ Use g:scnvim_scdoc_render_prg instead.
+        \ See :h scnvim-help-system for more details.'
+  echohl None
+endif

--- a/sc/Classes/SCNvimDoc/extSCNvim.sc
+++ b/sc/Classes/SCNvimDoc/extSCNvim.sc
@@ -35,7 +35,7 @@
         ^result;
     }
 
-    *openHelpFor {|text, pattern, pandocPath|
+    *openHelpFor {|text, pattern, renderPrg, renderArgs|
         var msg, uri, path;
         var outputPath;
 
@@ -54,8 +54,8 @@
             // help file
             // removes .html.scnvim
             outputPath = path.drop(-12) ++ ".txt";
-            // convert to plain text with pandoc
-            "% \"%\" --from html --to plain -o \"%\"".format(pandocPath, path, outputPath).unixCmdGetStdOut;
+            // convert to plain text
+            (renderPrg ++ " " ++ renderArgs).format(path.escapeChar($ ), outputPath.escapeChar($ )).unixCmdGetStdOut;
             msg = (action: "help_open_file", args: (uri: outputPath, pattern: pattern));
         } {
             // search for method
@@ -65,8 +65,8 @@
         SCNvim.sendJSON(msg);
     }
 
-    *renderMethod {|uri, pattern, pandocPath|
+    *renderMethod {|uri, pattern, renderPrg, renderArgs|
         var name = PathName(uri).fileNameWithoutExtension;
-        SCNvim.openHelpFor(name, pattern, pandocPath);
+        SCNvim.openHelpFor(name, pattern, renderPrg, renderArgs);
     }
 }


### PR DESCRIPTION
As requested in #85  

This introduces `g:scnvim_scdoc_render_prg` and `g:scnvim_scdoc_render_args` which can be set to use a different executable other than `pandoc` (which is the default).

**Example configuration**

```vim
let g:scnvim_scdoc_render_prg = '/usr/local/bin/html2text'
let g:scnvim_scdoc_render_args = '% -o %'
```

This deprecates `g:scnvim_pandoc_executable` use `g:scnvim_scdoc_render_prg` if a custom path is needed.

Closes #85