### PR TITLE
Colour syntax for post window

### DIFF
--- a/doc/SCNvim.txt
+++ b/doc/SCNvim.txt
@@ -205,6 +205,10 @@ Browse SuperCollider documentation in nvim (see |scnvim-help-system| for more in
 >
   let g:scnvim_scdoc = 1
 
+Disable syntax colouring in the post window (on by default)
+>
+  let g:scnvim_postwin_syntax_hl = 0
+
 Sclang Options Customization ~
 
 If you wanted to pass options to the call that SCNVim uses when it starts

--- a/doc/SCNvim.txt
+++ b/doc/SCNvim.txt
@@ -143,6 +143,10 @@ defaults.
 Run `:checkhealth` to diagnose common problems with your config.
 
 Post window~
+Disable syntax colouring in the post window 
+Default is 1 (on)
+>
+  let g:scnvim_postwin_syntax_hl = 0
 
 Vertical "v" or horizontal "h" split.
 >
@@ -204,10 +208,6 @@ Set this variable if you don't want any default mappings
 Browse SuperCollider documentation in nvim (see |scnvim-help-system| for more information)
 >
   let g:scnvim_scdoc = 1
-
-Disable syntax colouring in the post window (on by default)
->
-  let g:scnvim_postwin_syntax_hl = 0
 
 Sclang Options Customization ~
 

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -57,6 +57,9 @@ if (g:scnvim_postwin_syntax_hl == 1)
 
 	syn region compiling start=/\ccompil/ end=/$/
 
+	" Matches boot messages
+	syn match serverMessage /^\w*\W*:/
+	syn match ipAddr /\d\+.\d\+.\d\+.\d\+:\d\+/
 	"""""""""""""""""""
 	" Linking
 	"""""""""""""""""""
@@ -70,6 +73,9 @@ if (g:scnvim_postwin_syntax_hl == 1)
 	hi def link instanceError WarningMsg
 	hi def link warns WarningMsg
 	hi def link separator scComment
+
+	hi def link ipAddr Underlined
+	hi def link serverMessage Title
 
 	hi def link welcome Title
 	hi def link welcomeWords Title

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -14,7 +14,7 @@ if exists('b:current_syntax')
 endif
 let b:current_syntax = 'scnvim'
 
-if (g:scnvim_colour_post_window == 1)
+if (g:scnvim_postwin_syntax_hl == 1)
 
 	" syn clear
 	syn case match " Not case sensitive

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -11,7 +11,7 @@ scriptencoding utf-8
 
 " Check if syntax highlighting for the post window is active
 if !get(g:, 'scnvim_postwin_syntax_hl', 1)
-  finish
+	finish
 end
 
 " Check if this syntax file has been loaded before
@@ -20,69 +20,67 @@ if exists('b:current_syntax')
 endif
 let b:current_syntax = 'scnvim'
 
-if (g:scnvim_postwin_syntax_hl == 1)
+" syn clear
+syn case match " Not case sensitive
 
-	" syn clear
-	syn case match " Not case sensitive
+" Result of execution
+syn region result start=/->/ end=/\n/
 
-	" Result of execution
-	syn region result start=/->/ end=/\n/
+"""""""""""""""""""
+" Error and warning messages
+"""""""""""""""""""
+syn keyword errors ERROR
+syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK
+syn keyword info Info
 
-	"""""""""""""""""""
-	" Error and warning messages
-	"""""""""""""""""""
-	syn keyword errors ERROR
-	syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK
-	syn keyword info Info
+" for instance blocks in stack errors ala <Instance of Object> 
+syn region instanceError start=/</ end=/>/
 
-	" for instance blocks in stack errors ala <Instance of Object> 
-	syn region instanceError start=/</ end=/>/
+" Seperator after error
+syn match separator /-----------------------------------/
 
-	" Seperator after error
-	syn match separator /-----------------------------------/
+" Syntax error position
+syn match syntaxErrLine /line \d\+/ contained
+syn match syntaxErrChar /char \d\+:/ contained
+syn match syntaxErrCursor / ^/ contained
+syn region syntaxErrorContent start=/line \d\+ char \d\+/ end=/ ^/ contains=syntaxErrLine,syntaxErrChar
 
-	" Syntax error position
-	syn match syntaxErrLine /line \d\+/ contained
-	syn match syntaxErrChar /char \d\+:/ contained
-	syn match syntaxErrCursor / ^/ contained
-	syn region syntaxErrorContent start=/line \d\+ char \d\+/ end=/ ^/ contains=syntaxErrLine,syntaxErrChar
+"""""""""""""""""""
+" Misc
+"""""""""""""""""""
 
-	"""""""""""""""""""
-	" Misc
-	"""""""""""""""""""
+" Welcome message
+" syn region welcome start=/\*\*\*/ end=/\*\*\*/
+syn match welcomeWords "Welcome to SuperCollider"
+syn region welcome start=/\*\*\*/ end=/$/ contains=welcomeWords
 
-	" Welcome message
-	" syn region welcome start=/\*\*\*/ end=/\*\*\*/
-	syn match welcomeWords "Welcome to SuperCollider"
-	syn region welcome start=/\*\*\*/ end=/$/ contains=welcomeWords
+syn region compiling start=/\ccompil/ end=/$/
 
-	syn region compiling start=/\ccompil/ end=/$/
+" Matches boot messages
+syn match serverMessage /^\w*\W*:/
+syn match ipAddr /\d\+.\d\+.\d\+.\d\+:\d\+/
 
-	" Matches boot messages
-	syn match serverMessage /^\w*\W*:/
-	syn match ipAddr /\d\+.\d\+.\d\+.\d\+:\d\+/
-	"""""""""""""""""""
-	" Linking
-	"""""""""""""""""""
+"""""""""""""""""""
+" Linking
+"""""""""""""""""""
 
-	" Special scnvim links
-	hi def link errors ErrorMsg
-	hi def link syntaxErrLine Underlined
-	hi def link syntaxErrChar Underlined
-	hi def link syntaxErrCursor TerminalCursor
-	hi def link syntaxErrorContent WarningMsg
-	hi def link instanceError WarningMsg
-	hi def link warns WarningMsg
-	hi def link separator scComment
+" Special scnvim links
+hi def link errors ErrorMsg
+hi def link syntaxErrLine Underlined
+hi def link syntaxErrChar Underlined
+hi def link syntaxErrCursor TerminalCursor
+hi def link syntaxErrorContent WarningMsg
+hi def link instanceError WarningMsg
+hi def link warns WarningMsg
+hi def link separator scComment
 
-	hi def link ipAddr Underlined
-	hi def link serverMessage Title
-	hi def link info Title
+hi def link ipAddr Underlined
+hi def link serverMessage Title
+hi def link info Title
 
 
-	hi def link welcome Title
-	hi def link welcomeWords Title
-	hi def link compiling Comment
+hi def link welcome Title
+hi def link welcomeWords Title
+hi def link compiling Comment
 
-	hi def link result String
-endif
+hi def link result String

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -14,11 +14,17 @@ if exists('b:current_syntax')
 endif
 let b:current_syntax = 'scnvim'
 
+syn clear
 syn case match " Not case sensitive
-syn keyword errors ERROR
-syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK
 
-" Error messages
+" Result of execution
+syn region result start=/->/ end=/\n/
+
+"""""""""""""""""""
+" Error and warning messages
+"""""""""""""""""""
+syn keyword errors ERROR
+syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK Info
 
 " for instance blocks in stack errors ala <Instance of Object> 
 syn region instanceError start=/</ end=/>/
@@ -26,13 +32,43 @@ syn region instanceError start=/</ end=/>/
 " Seperator after error
 syn match separator /-----------------------------------/
 
-" Result of execution
-syn region result start=/->/ end=/\n/
+" Syntax error position
+syn match syntaxErrLine /line \d\+/ contained
+syn match syntaxErrChar /char \d\+:/ contained
+syn match syntaxErrCursor / ^/ contained
+syn region syntaxErrorContent start=/line \d\+ char \d\+/ end=/ ^/ contains=syntaxErrLine,syntaxErrChar
 
-" Set highlight colors
-hi def link scObject Identifier
+"""""""""""""""""""
+" Misc
+"""""""""""""""""""
+
+" Welcome message
+" syn region welcome start=/\*\*\*/ end=/\*\*\*/
+syn match welcomeWords "Welcome to SuperCollider"
+syn region welcome start=/\*\*\*/ end=/$/ contains=welcomeWords
+
+syn region compiling start=/\ccompil/ end=/$/
+
+"""""""""""""""""""
+" Linking
+"""""""""""""""""""
+
+" Special scnvim links
 hi def link errors ErrorMsg
+hi def link syntaxErrLine Underlined
+hi def link syntaxErrChar Underlined
+hi def link syntaxErrCursor TerminalCursor
+hi def link syntaxErrorContent WarningMsg
 hi def link instanceError WarningMsg
 hi def link warns WarningMsg
 hi def link separator Comment
+
+hi def link welcome Title
+hi def link welcomeWords Title
+hi def link compiling Comment
+
 hi def link result String
+
+" supercollider.vim links
+" hi def link scFloat Float
+" hi def link scObject Identifier

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -14,6 +14,7 @@ if !get(g:, 'scnvim_postwin_syntax_hl', 1)
   finish
 end
 
+" Check if this syntax file has been loaded before
 if exists('b:current_syntax')
 	finish
 endif

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -1,0 +1,38 @@
+" Syntax highlighting for the scnvim post window
+"
+" By Mads Kjeldgaard
+" 2020-05-11
+"
+"
+" Building on the work of Alex Norman, David Granström and Stephen Lumenta for
+" SuperCollider, SCVIM and SCNVIM.
+
+scriptencoding utf-8
+
+if exists('b:current_syntax')
+  finish
+endif
+let b:current_syntax = 'scnvim'
+
+syn case match " Not case sensitive
+syn keyword errors ERROR
+syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK
+
+" Error messages
+
+" for instance blocks in stack errors ala <Instance of Object> 
+syn region instanceError start=/</ end=/>/
+
+" Seperator after error
+syn match separator /-----------------------------------/
+
+" Result of execution
+syn region result start=/->/ end=/\n/
+
+" Set highlight colors
+hi def link scObject Identifier
+hi def link errors ErrorMsg
+hi def link instanceError WarningMsg
+hi def link warns WarningMsg
+hi def link separator Comment
+hi def link result String

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -70,8 +70,4 @@ if (g:scnvim_colour_post_window == 1)
 	hi def link compiling Comment
 
 	hi def link result String
-
-	" supercollider.vim links
-	" hi def link scFloat Float
-	" hi def link scObject Identifier
 endif

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -9,6 +9,11 @@
 
 scriptencoding utf-8
 
+" Check if syntax highlighting for the post window is active
+if !get(g:, 'scnvim_postwin_syntax_hl', 1)
+  finish
+end
+
 if exists('b:current_syntax')
 	finish
 endif

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -32,7 +32,8 @@ if (g:scnvim_postwin_syntax_hl == 1)
 	" Error and warning messages
 	"""""""""""""""""""
 	syn keyword errors ERROR
-	syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK Info
+	syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK
+	syn keyword info Info
 
 	" for instance blocks in stack errors ala <Instance of Object> 
 	syn region instanceError start=/</ end=/>/
@@ -76,6 +77,8 @@ if (g:scnvim_postwin_syntax_hl == 1)
 
 	hi def link ipAddr Underlined
 	hi def link serverMessage Title
+	hi def link info Title
+
 
 	hi def link welcome Title
 	hi def link welcomeWords Title

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -10,65 +10,68 @@
 scriptencoding utf-8
 
 if exists('b:current_syntax')
-  finish
+	finish
 endif
 let b:current_syntax = 'scnvim'
 
-syn clear
-syn case match " Not case sensitive
+if (g:scnvim_colour_post_window == 1)
 
-" Result of execution
-syn region result start=/->/ end=/\n/
+	" syn clear
+	syn case match " Not case sensitive
 
-"""""""""""""""""""
-" Error and warning messages
-"""""""""""""""""""
-syn keyword errors ERROR
-syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK Info
+	" Result of execution
+	syn region result start=/->/ end=/\n/
 
-" for instance blocks in stack errors ala <Instance of Object> 
-syn region instanceError start=/</ end=/>/
+	"""""""""""""""""""
+	" Error and warning messages
+	"""""""""""""""""""
+	syn keyword errors ERROR
+	syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK Info
 
-" Seperator after error
-syn match separator /-----------------------------------/
+	" for instance blocks in stack errors ala <Instance of Object> 
+	syn region instanceError start=/</ end=/>/
 
-" Syntax error position
-syn match syntaxErrLine /line \d\+/ contained
-syn match syntaxErrChar /char \d\+:/ contained
-syn match syntaxErrCursor / ^/ contained
-syn region syntaxErrorContent start=/line \d\+ char \d\+/ end=/ ^/ contains=syntaxErrLine,syntaxErrChar
+	" Seperator after error
+	syn match separator /-----------------------------------/
 
-"""""""""""""""""""
-" Misc
-"""""""""""""""""""
+	" Syntax error position
+	syn match syntaxErrLine /line \d\+/ contained
+	syn match syntaxErrChar /char \d\+:/ contained
+	syn match syntaxErrCursor / ^/ contained
+	syn region syntaxErrorContent start=/line \d\+ char \d\+/ end=/ ^/ contains=syntaxErrLine,syntaxErrChar
 
-" Welcome message
-" syn region welcome start=/\*\*\*/ end=/\*\*\*/
-syn match welcomeWords "Welcome to SuperCollider"
-syn region welcome start=/\*\*\*/ end=/$/ contains=welcomeWords
+	"""""""""""""""""""
+	" Misc
+	"""""""""""""""""""
 
-syn region compiling start=/\ccompil/ end=/$/
+	" Welcome message
+	" syn region welcome start=/\*\*\*/ end=/\*\*\*/
+	syn match welcomeWords "Welcome to SuperCollider"
+	syn region welcome start=/\*\*\*/ end=/$/ contains=welcomeWords
 
-"""""""""""""""""""
-" Linking
-"""""""""""""""""""
+	syn region compiling start=/\ccompil/ end=/$/
 
-" Special scnvim links
-hi def link errors ErrorMsg
-hi def link syntaxErrLine Underlined
-hi def link syntaxErrChar Underlined
-hi def link syntaxErrCursor TerminalCursor
-hi def link syntaxErrorContent WarningMsg
-hi def link instanceError WarningMsg
-hi def link warns WarningMsg
-hi def link separator Comment
+	"""""""""""""""""""
+	" Linking
+	"""""""""""""""""""
 
-hi def link welcome Title
-hi def link welcomeWords Title
-hi def link compiling Comment
+	" Special scnvim links
+	hi def link errors ErrorMsg
+	hi def link syntaxErrLine Underlined
+	hi def link syntaxErrChar Underlined
+	hi def link syntaxErrCursor TerminalCursor
+	hi def link syntaxErrorContent WarningMsg
+	hi def link instanceError WarningMsg
+	hi def link warns WarningMsg
+	hi def link separator scComment
 
-hi def link result String
+	hi def link welcome Title
+	hi def link welcomeWords Title
+	hi def link compiling Comment
 
-" supercollider.vim links
-" hi def link scFloat Float
-" hi def link scObject Identifier
+	hi def link result String
+
+	" supercollider.vim links
+	" hi def link scFloat Float
+	" hi def link scObject Identifier
+endif


### PR DESCRIPTION
This is a pull request to add syntax colouring to the post window. 

The goal of this is to make the post window output easier to read, especially for warning and error messages.

The colouring can be toggled on/off by modifying the global variable `g:scnvim_colour_post_window` and setting it to 1/0. 

Below are examples of it in use:

![2020-11-05-124543_1920x1080_scrot](https://user-images.githubusercontent.com/22474608/98269191-c1f76d80-1f8d-11eb-9332-4e80b79baf18.png)
![2020-11-05-115815_1920x1080_scrot](https://user-images.githubusercontent.com/22474608/98269222-c91e7b80-1f8d-11eb-814e-02f168cd8cd5.png)

It is currently a work in progress.