### PR TITLE
Vim help file code block syntax highlighting

### DIFF
--- a/scide_scnvim/Classes/SCNvimDoc/SCNvimDocRenderer.sc
+++ b/scide_scnvim/Classes/SCNvimDoc/SCNvimDocRenderer.sc
@@ -48,7 +48,7 @@ SCNvimDocRenderer : SCDocHTMLRenderer {
 		doc.fullPath !? {
             stream << "<div>helpfile source: " << doc.fullPath << "</div>";
 		};
-        stream << "<div> vim:tw=78:et:ft=scnvimhelp:norl:<\div>";
+        stream << "<div> vim:tw=78:et:ft=scnvimhelp.help:norl:<\div>";
         stream << "</body></html>";
 	}
 

--- a/scide_scnvim/Classes/SCNvimDoc/SCNvimDocRenderer.sc
+++ b/scide_scnvim/Classes/SCNvimDoc/SCNvimDocRenderer.sc
@@ -48,7 +48,7 @@ SCNvimDocRenderer : SCDocHTMLRenderer {
 		doc.fullPath !? {
             stream << "<div>helpfile source: " << doc.fullPath << "</div>";
 		};
-        stream << "<div> vim:tw=78:et:ft=help.supercollider:norl:<\div>";
+        stream << "<div> vim:tw=78:et:ft=scnvimhelp:norl:<\div>";
         stream << "</body></html>";
 	}
 
@@ -226,10 +226,16 @@ SCNvimDocRenderer : SCDocHTMLRenderer {
 				stream << this.htmlForLink(node.text);
 			},
 			\CODEBLOCK, {
-                stream << "<pre><code>"
-                << ">\n"
+                stream 
+				<< "/* SCNVIM_SNIP_START */"
+				<< "\n"
+				<< "<pre><code>"
+                // << ">\n"
 				<< this.escapeSpecialChars(node.text)
-                << "</code></pre>";
+				<< "\n"
+                << "</code></pre>"
+				<< "\n"
+				<< "/* SCNVIM_SNIP_END */";
 			},
 			\CODE, {
                 stream << "<code>"

--- a/syntax/scnvimhelp.vim
+++ b/syntax/scnvimhelp.vim
@@ -9,7 +9,7 @@ runtime! syntax/help.vim
 let b:current_syntax = ''
 unlet b:current_syntax
 syntax include @SC syntax/supercollider.vim
-syntax region scSnip matchgroup=Snip start="//SCNVIM_SNIP_START" end="//SCNVIM_SNIP_END" contains=@SC
+syntax region scSnipCodeBlock matchgroup=Snip start="\* SCNVIM_SNIP_START \*/" end="\* SCNVIM_SNIP_END \*/" contains=@SC
 hi link Snip Comment
 
 let b:current_syntax = 'scnvimhelp' 

--- a/syntax/scnvimhelp.vim
+++ b/syntax/scnvimhelp.vim
@@ -12,4 +12,4 @@ syntax include @SC syntax/supercollider.vim
 syntax region scSnipCodeBlock matchgroup=Snip start="\* SCNVIM_SNIP_START \*/" end="\* SCNVIM_SNIP_END \*/" contains=@SC
 hi link Snip Comment
 
-let b:current_syntax = 'scnvimhelp' 
+let b:current_syntax = 'scnvimhelp.help' 

--- a/syntax/scnvimhelp.vim
+++ b/syntax/scnvimhelp.vim
@@ -1,0 +1,15 @@
+scriptencoding utf-8
+
+" Without the two following lines, neco-syntax will create trouble
+let b:current_syntax = ''
+unlet b:current_syntax
+runtime! syntax/help.vim
+
+" Needed when importing syntax highlighting
+let b:current_syntax = ''
+unlet b:current_syntax
+syntax include @SC syntax/supercollider.vim
+syntax region scSnip matchgroup=Snip start="//SCNVIM_SNIP_START" end="//SCNVIM_SNIP_END" contains=@SC
+hi link Snip Comment
+
+let b:current_syntax = 'scnvimhelp' 


### PR DESCRIPTION
![2020-11-09-102627_1920x1080_scrot](https://user-images.githubusercontent.com/22474608/98523485-42f88280-2276-11eb-91c4-af48d0022b23.png)

This PR adds support for syntax highlighting inside code blocks in scnvim's help files for SC classes.