### PR TITLE
Add error color for unittest FAIL

### DIFF
--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -29,7 +29,7 @@ syn region result start=/->/ end=/\n/
 """""""""""""""""""
 " Error and warning messages
 """""""""""""""""""
-syn keyword errors ERROR
+syn keyword errors ERROR FAIL
 syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK
 syn keyword info Info
 


### PR DESCRIPTION
This adds error message color coding to FAIL-messages which are the result of using the UnitTest class and makes it easier to read errors :)