### PR TITLE
Override nvim default scala filetype detection

### DIFF
--- a/ftdetect/supercollider.vim
+++ b/ftdetect/supercollider.vim
@@ -1,3 +1,4 @@
 " vint: -ProhibitAutocmdWithNoGroup
-autocmd BufEnter,BufWinEnter,BufNewFile,BufRead *.sc,*.scd set filetype=supercollider
+autocmd! BufEnter,BufWinEnter,BufNewFile,BufRead *.sc set filetype=supercollider
+autocmd BufEnter,BufWinEnter,BufNewFile,BufRead *.scd set filetype=supercollider
 autocmd BufEnter,BufWinEnter,BufNewFile,BufRead *.schelp set filetype=scdoc


### PR DESCRIPTION
Fix for avoiding `nvim`'s default filetype detection for `.sc`-files being of filetype `scala`. Fixes #156 