### PR TITLE
feat: add luaeval handler to json communication

### DIFF
--- a/lua/scnvim/udp.lua
+++ b/lua/scnvim/udp.lua
@@ -45,7 +45,10 @@ end
 function Handlers.luaeval(codestring)
   if not codestring then return end
   local func = loadstring(codestring)
-  func()
+  local ok, result = pcall(func)
+  if not ok then
+    print('[scnvim] luaeval: ' .. result)
+  end
 end
 
 --- Receive data from sclang

--- a/lua/scnvim/udp.lua
+++ b/lua/scnvim/udp.lua
@@ -41,6 +41,13 @@ function Handlers.help_find_method(args)
   help.handle_method(args.method_name, args.helpTargetDir)
 end
 
+--- Evaluate a piece of lua code sent from sclang
+function Handlers.luaeval(codestring)
+  if not codestring then return end
+  local func = loadstring(codestring)
+  func()
+end
+
 --- Receive data from sclang
 function Handlers.eval(result)
   assert(result)

--- a/scide_scnvim/Classes/SCNvim.sc
+++ b/scide_scnvim/Classes/SCNvim.sc
@@ -16,6 +16,10 @@ SCNvim {
         }
     }
 
+    *luaeval{|luacode|
+        SCNvim.sendJSON((action: "luaeval", args: luacode))
+    }
+
     *eval {|expr|
         var result = expr.interpret;
         result = (action: "eval", args: result);


### PR DESCRIPTION
This adds another Handler function which interprets luacode sent from sclang. This is mostly useful as an addition to the existing API which would make it easy to control NeoVim from sclang.

```supercollider
SCNvim.luaeval("print(\"sclang says hi\")")
```
A possible usecase for this is a SuperCollider class with some of the common neovim api actions ready to go. I imagine class methods in SC ala `NeoVim*buf_set_lines()` allowing to insert text into neovim buffers from SuperCollider. This interface is outside of the scope of this PR (and possibly scnvim as well?).