### PR TITLE
scnvim.eval: Store callbacks in a dictionary instead of a list

### DIFF
--- a/lua/scnvim/sclang.lua
+++ b/lua/scnvim/sclang.lua
@@ -125,8 +125,8 @@ function M.send(data, silent)
 end
 
 function M.eval(expr, cb)
-  local cmd = string.format('SCNvim.eval("%s");', expr)
-  udp.push_eval_callback(cb)
+  local id = udp.push_eval_callback(cb)
+  local cmd = string.format('SCNvim.eval("%s", "%s");', expr, id)
   M.send(cmd, true)
 end
 

--- a/lua/scnvim/udp.lua
+++ b/lua/scnvim/udp.lua
@@ -11,6 +11,7 @@ local M = {}
 local HOST = '127.0.0.1'
 local PORT = 0
 local eval_callbacks = {}
+local callback_id = '0'
 
 --- UDP handlers.
 -- Run the matching function in this table for the incoming 'action' parameter.
@@ -52,11 +53,12 @@ function Handlers.luaeval(codestring)
 end
 
 --- Receive data from sclang
-function Handlers.eval(result)
-  assert(result)
-  local callback = table.remove(eval_callbacks)
+function Handlers.eval(object)
+  assert(object)
+  local callback = eval_callbacks[object.id]
   if callback then
-    callback(result)
+    callback(object.result)
+    eval_callbacks[object.id] = nil
   end
 end
 
@@ -99,13 +101,12 @@ end
 --- Push a callback to be evaluated later.
 -- utility function for the scnvim.eval API.
 function M.push_eval_callback(cb)
-  -- need to check this for nvim versions < 0.5
-  if vim.validate then
-    vim.validate{
-      cb = {cb, 'function'}
-    }
-  end
-  table.insert(eval_callbacks, cb)
+  vim.validate{
+    cb = {cb, 'function'}
+  }
+  callback_id = tostring(tonumber(callback_id) + 1)
+  eval_callbacks[callback_id] = cb
+  return callback_id
 end
 
 return M

--- a/scide_scnvim/Classes/SCNvim.sc
+++ b/scide_scnvim/Classes/SCNvim.sc
@@ -20,9 +20,9 @@ SCNvim {
         SCNvim.sendJSON((action: "luaeval", args: luacode))
     }
 
-    *eval {|expr|
+    *eval {|expr, callback_id|
         var result = expr.interpret;
-        result = (action: "eval", args: result);
+        result = (action: "eval", args: (result: result, id: callback_id));
         SCNvim.sendJSON(result);
     }
 


### PR DESCRIPTION
This fixes a long standing issue where lua callbacks could be overwritten depending on order of execution in sclang.