### PR TITLE
*.sc, *.scd, *.quark are natively recognized in 0.7

### DIFF
--- a/ftdetect/filetype.lua
+++ b/ftdetect/filetype.lua
@@ -1,8 +1,6 @@
 if vim.fn.has "nvim-0.7" == 1 and vim.g.do_filetype_lua == 1 then
   vim.filetype.add {
     extension = {
-      sc = "supercollider",
-      scd = "supercollider",
       schelp = "scdoc",
     },
   }

--- a/ftdetect/supercollider.vim
+++ b/ftdetect/supercollider.vim
@@ -1,6 +1,9 @@
 " vint: -ProhibitAutocmdWithNoGroup
-if !has('nvim-0.7') || !exists('g:do_filetype_lua')
+if !has('nvim-0.7') 
   autocmd! BufEnter,BufWinEnter,BufNewFile,BufRead *.sc set filetype=supercollider
   autocmd BufEnter,BufWinEnter,BufNewFile,BufRead *.scd set filetype=supercollider
+  autocmd BufEnter,BufWinEnter,BufNewFile,BufRead *.quark set filetype=supercollider
+  autocmd BufEnter,BufWinEnter,BufNewFile,BufRead *.schelp set filetype=scdoc
+elseif !exists('g:do_filetype_lua')
   autocmd BufEnter,BufWinEnter,BufNewFile,BufRead *.schelp set filetype=scdoc
 endif


### PR DESCRIPTION
Integrate with 0.7 release by removing redundant detects.
Add conditional to check for version and lua_filetype variable

0.7 was released earlier today