### PR TITLE
fix: Simplify scnvim postwindow highlighting

### DIFF
--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -20,45 +20,32 @@ if exists('b:current_syntax')
 endif
 let b:current_syntax = 'scnvim'
 
-" syn clear
 syn case match " Not case sensitive
 
 " Result of execution
-syn region result start=/->/ end=/\n/
+syn region result start=/^->/ end=/\n/
+
+" Using Log.quark
+syn match logger /^\[\w*\]/
 
 """""""""""""""""""
 " Error and warning messages
 """""""""""""""""""
-syn keyword errors ERROR FAIL
-syn keyword warns WARNING RECEIVER ARGS PATH CALL STACK
-syn keyword info Info
+syn match errorCursor "\^\^"
+syn match errors /ERROR:.*$/
+syn match receiverError /RECEIVER:.*$/
+syn match fails /FAIL:.*$/
+syn match warns /WARNING:.*$/
+syn match exceptions /EXCEPTION:.*$/
 
-" for instance blocks in stack errors ala <Instance of Object> 
-syn region instanceError start=/</ end=/>/
+syn match errorblock /^ERROR:.*\_.*\ze\^\^/
+syn match receiverBlock /^RECEIVER:.*\_.*\^\^/
+syn match protectedcallstack /^PROTECTED CALL STACK:.*\_.*\ze\^\^/
+syn match callstack /^CALL STACK:.*\_.*\ze\^\^/
 
-" Seperator after error
-syn match separator /-----------------------------------/
-
-" Syntax error position
-syn match syntaxErrLine /line \d\+/ contained
-syn match syntaxErrChar /char \d\+:/ contained
-syn match syntaxErrCursor / ^/ contained
-syn region syntaxErrorContent start=/line \d\+ char \d\+/ end=/ ^/ contains=syntaxErrLine,syntaxErrChar
-
-"""""""""""""""""""
-" Misc
-"""""""""""""""""""
-
-" Welcome message
-" syn region welcome start=/\*\*\*/ end=/\*\*\*/
-syn match welcomeWords "Welcome to SuperCollider"
-syn region welcome start=/\*\*\*/ end=/$/ contains=welcomeWords
-
-syn region compiling start=/\ccompil/ end=/$/
-
-" Matches boot messages
-syn match serverMessage /^\w*\W*:/
-syn match ipAddr /\d\+.\d\+.\d\+.\d\+:\d\+/
+" unittests
+syn match unittestPass /^PASS:.*$/
+syn match unittestRunning /^RUNNING UNIT TEST.*$/
 
 """""""""""""""""""
 " Linking
@@ -66,21 +53,19 @@ syn match ipAddr /\d\+.\d\+.\d\+.\d\+:\d\+/
 
 " Special scnvim links
 hi def link errors ErrorMsg
-hi def link syntaxErrLine Underlined
-hi def link syntaxErrChar Underlined
-hi def link syntaxErrCursor TerminalCursor
-hi def link syntaxErrorContent WarningMsg
-hi def link instanceError WarningMsg
+hi def link errorBlock ErrorMsg
+hi def link receiverError ErrorMsg
+hi def link exceptions ErrorMsg
+hi def link errorCursor Bold
+hi def link fails ErrorMsg
+hi def link syntaxErrorContent Underlined
 hi def link warns WarningMsg
-hi def link separator scComment
 
-hi def link ipAddr Underlined
-hi def link serverMessage Title
-hi def link info Title
+hi def link receiverBlock WarningMsg
+hi def link callstack WarningMsg
+hi def link protectedcallstack WarningMsg
 
-
-hi def link welcome Title
-hi def link welcomeWords Title
-hi def link compiling Comment
+hi def link logger Bold
+hi def link unittestPass String
 
 hi def link result String

--- a/syntax/scnvim.vim
+++ b/syntax/scnvim.vim
@@ -38,10 +38,10 @@ syn match fails /FAIL:.*$/
 syn match warns /WARNING:.*$/
 syn match exceptions /EXCEPTION:.*$/
 
-syn match errorblock /^ERROR:.*\_.*\ze\^\^/
-syn match receiverBlock /^RECEIVER:.*\_.*\^\^/
-syn match protectedcallstack /^PROTECTED CALL STACK:.*\_.*\ze\^\^/
-syn match callstack /^CALL STACK:.*\_.*\ze\^\^/
+syn match errorblock /^ERROR:.*$/
+syn match receiverBlock /^RECEIVER:.*$/
+syn match protectedcallstack /^PROTECTED CALL STACK:.*$/
+syn match callstack /^CALL STACK:.*$/
 
 " unittests
 syn match unittestPass /^PASS:.*$/


### PR DESCRIPTION
This pull requests fixes a number of reg ex issues in the highlighting for the scnvim post window and simplifies the process a bit. 

This is highly opinionated, but I found some of the matches in the first version of this noisy and have opted for simpler matches now where in stead of for example an error mesage only making the ERROR part red, it now makes the whole error message red. The same for the call stacks and other tid bits. This makes it easier to see from a glance if everyting is okay.

It also adds some unit test matching, matches for https://github.com/scztt/Log.quark type messages. 

Here are some examples of what it looks like now:
![2022-04-18_1920x1080_003](https://user-images.githubusercontent.com/22474608/163798038-2fcff29f-e678-4011-bb2d-39be02c23bdd.png)

![2022-04-18_1920x1080_004](https://user-images.githubusercontent.com/22474608/163797988-00616571-e199-481c-b3a8-f8c859c70bfc.png)

