### PR TITLE
fixed redundant escape characters

### DIFF
--- a/lua/scnvim/sclang.lua
+++ b/lua/scnvim/sclang.lua
@@ -153,7 +153,7 @@ end
 function M.generate_assets(on_done)
   assert(M.is_running(), '[scnvim] sclang not running')
   local format = config.snippet.engine.name
-  local expr = string.format([[SCNvim.generateAssets(\"%s\", \"%s\")]], path.get_cache_dir(), format)
+  local expr = string.format([[SCNvim.generateAssets("%s", "%s")]], path.get_cache_dir(), format)
   M.eval(expr, on_done)
 end
 


### PR DESCRIPTION
Removes redundant escape strings in sclang.lua that prevent `SCNvimGenerateAssets` from working.