### PR TITLE
feat: add desc option to scnvim.map, close #202

### DIFF
--- a/lua/scnvim/editor.lua
+++ b/lua/scnvim/editor.lua
@@ -145,10 +145,10 @@ local function apply_keymaps(mappings)
     -- handle list of keymaps to same key
     if value[1] ~= nil then
       for _, v in ipairs(value) do
-        vim.keymap.set(v.modes, key, v.fn, { buffer = true })
+        vim.keymap.set(v.modes, key, v.fn, { buffer = true, desc = v.desc or "scnvim keymap" })
       end
     else
-      vim.keymap.set(value.modes, key, value.fn, { buffer = true })
+      vim.keymap.set(value.modes, key, value.fn, { buffer = true, desc = value.desc or "scnvim keymap" })
     end
   end
 end

--- a/lua/scnvim/map.lua
+++ b/lua/scnvim/map.lua
@@ -40,7 +40,7 @@ local function validate(str)
 end
 
 local map = setmetatable({}, {
-  __call = function(_, fn, modes, callback, flash)
+  __call = function(_, fn, modes, desc, callback, flash)
     modes = type(modes) == 'string' and { modes } or modes
     modes = modes or { 'n' }
     if type(fn) == 'string' then
@@ -52,19 +52,19 @@ local map = setmetatable({}, {
           require(module)[cmd]()
         end
       end
-      return { modes = modes, fn = wrapper }
+      return { modes = modes, fn = wrapper, desc = desc }
     elseif type(fn) == 'function' then
-      return { modes = modes, fn = fn }
+      return { modes = modes, fn = fn, desc = desc }
     end
   end,
 })
 
-local map_expr = function(expr, modes, silent)
+local map_expr = function(expr, modes, desc, silent)
   modes = type(modes) == 'string' and { modes } or modes
   silent = silent == nil and true or silent
   return map(function()
     require('scnvim.sclang').send(expr, silent)
-  end, modes)
+  end, modes, desc)
 end
 
 return {


### PR DESCRIPTION
Not sure if this would create any issues/breaking-changes in regard to the _callback_ and _flash_ params/args of the apply_keymap func? It seems logical to have `desc` as the third param. Please advice. **:)**