### PR TITLE
Support description for keymaps

### DIFF
--- a/lua/scnvim/editor.lua
+++ b/lua/scnvim/editor.lua
@@ -145,10 +145,18 @@ local function apply_keymaps(mappings)
     -- handle list of keymaps to same key
     if value[1] ~= nil then
       for _, v in ipairs(value) do
-        vim.keymap.set(v.modes, key, v.fn, { buffer = true })
+        local opts = {
+          buffer = true,
+          desc = v.options.desc,
+        }
+        vim.keymap.set(v.modes, key, v.fn, opts)
       end
     else
-      vim.keymap.set(value.modes, key, value.fn, { buffer = true })
+      local opts = {
+        buffer = true,
+        desc = value.options.desc,
+      }
+      vim.keymap.set(value.modes, key, value.fn, opts)
     end
   end
 end

--- a/lua/scnvim/map.lua
+++ b/lua/scnvim/map.lua
@@ -40,31 +40,33 @@ local function validate(str)
 end
 
 local map = setmetatable({}, {
-  __call = function(_, fn, modes, callback, flash)
+  __call = function(_, fn, modes, options)
     modes = type(modes) == 'string' and { modes } or modes
     modes = modes or { 'n' }
+    options = options or { desc = 'scnvim keymap' }
     if type(fn) == 'string' then
       local module, cmd = validate(fn)
       local wrapper = function()
         if module == 'scnvim.editor' then
-          require(module)[cmd](callback, flash)
+          require(module)[cmd](options.callback, options.flash)
         else
           require(module)[cmd]()
         end
       end
-      return { modes = modes, fn = wrapper }
+      return { modes = modes, fn = wrapper, options = options }
     elseif type(fn) == 'function' then
-      return { modes = modes, fn = fn }
+      return { modes = modes, fn = fn, options = options }
     end
   end,
 })
 
-local map_expr = function(expr, modes, silent)
+local map_expr = function(expr, modes, options)
   modes = type(modes) == 'string' and { modes } or modes
-  silent = silent == nil and true or silent
+  options = options or {}
+  options.silent = options.silent == nil and true or options.silent
   return map(function()
-    require('scnvim.sclang').send(expr, silent)
-  end, modes)
+    require('scnvim.sclang').send(expr, options.silent)
+  end, modes, options)
 end
 
 return {

--- a/test/spec/automated/map_spec.lua
+++ b/test/spec/automated/map_spec.lua
@@ -22,10 +22,13 @@ describe('map', function()
 
   it('can use callbacks for editor keymaps', function()
     local editor = require 'scnvim.editor'
-    local ret = map('editor.send_line', 'n', function(data)
-      assert.are.equal('foo', data[1])
-      return data
-    end)
+    local options = {
+      callback = function(data)
+        assert.are.equal('foo', data[1])
+        return data
+      end,
+    }
+    local ret = map('editor.send_line', 'n', options)
     editor.on_send:replace(function(lines, cb)
       if cb then
         cb(lines)
@@ -34,5 +37,12 @@ describe('map', function()
     vim.api.nvim_buf_set_lines(0, -2, -1, false, { 'foo' })
     ret.fn()
     editor.on_send:restore()
+  end)
+
+  it('sets a default description', function()
+    local ret = map('editor.send_line', 'n')
+    assert.are.equal('scnvim keymap', ret.options.desc)
+    ret = map('editor.send_line', 'n', { desc = 'custom desc' })
+    assert.are.equal('custom desc', ret.options.desc)
   end)
 end)


### PR DESCRIPTION
This commit changes the signature for the `map` and `map_expr` helpers in order to support descriptions for keymaps (and perhaps other keymap options in the future).

Here's an example:

```lua
keymaps = {
    ['<leader>st'] = map('sclang.start', 'n', { desc = 'Start the interpreter' }),
    ['<CR>'] = map('postwin.toggle', 'n', { desc = 'Toggle post window' }),
}
```

cc: @salkin-mada 

Close #202 