### PR TITLE
Add default keymap descriptions

### DIFF
--- a/lua/scnvim/map.lua
+++ b/lua/scnvim/map.lua
@@ -44,8 +44,8 @@ local map = setmetatable({}, {
     modes = type(modes) == 'string' and { modes } or modes
     modes = modes or { 'n' }
     options = options or {
-			desc = type(fn) == 'string' and ('scnvim: '..fn) or 'scnvim keymap'
-		}
+      desc = type(fn) == 'string' and ('scnvim: '..fn) or 'scnvim keymap'
+    }
     if type(fn) == 'string' then
       local module, cmd = validate(fn)
       local wrapper = function()
@@ -66,7 +66,7 @@ local map_expr = function(expr, modes, options)
   modes = type(modes) == 'string' and { modes } or modes
   options = options or {}
   options.silent = options.silent == nil and true or options.silent
-	options.desc = options.desc or 'sclang: '..expr
+  options.desc = options.desc or 'sclang: '..expr
   return map(function()
     require('scnvim.sclang').send(expr, options.silent)
   end, modes, options)

--- a/lua/scnvim/map.lua
+++ b/lua/scnvim/map.lua
@@ -43,7 +43,9 @@ local map = setmetatable({}, {
   __call = function(_, fn, modes, options)
     modes = type(modes) == 'string' and { modes } or modes
     modes = modes or { 'n' }
-    options = options or { desc = 'scnvim keymap' }
+    options = options or {
+			desc = type(fn) == 'string' and ('scnvim: '..fn) or 'scnvim keymap'
+		}
     if type(fn) == 'string' then
       local module, cmd = validate(fn)
       local wrapper = function()
@@ -64,6 +66,7 @@ local map_expr = function(expr, modes, options)
   modes = type(modes) == 'string' and { modes } or modes
   options = options or {}
   options.silent = options.silent == nil and true or options.silent
+	options.desc = options.desc or 'sclang: '..expr
   return map(function()
     require('scnvim.sclang').send(expr, options.silent)
   end, modes, options)

--- a/lua/scnvim/map.lua
+++ b/lua/scnvim/map.lua
@@ -44,7 +44,7 @@ local map = setmetatable({}, {
     modes = type(modes) == 'string' and { modes } or modes
     modes = modes or { 'n' }
     options = options or {
-      desc = type(fn) == 'string' and ('scnvim: '..fn) or 'scnvim keymap'
+      desc = type(fn) == 'string' and ('scnvim: ' .. fn) or 'scnvim keymap',
     }
     if type(fn) == 'string' then
       local module, cmd = validate(fn)
@@ -66,7 +66,7 @@ local map_expr = function(expr, modes, options)
   modes = type(modes) == 'string' and { modes } or modes
   options = options or {}
   options.silent = options.silent == nil and true or options.silent
-  options.desc = options.desc or 'sclang: '..expr
+  options.desc = options.desc or 'sclang: ' .. expr
   return map(function()
     require('scnvim.sclang').send(expr, options.silent)
   end, modes, options)

--- a/test/spec/automated/map_spec.lua
+++ b/test/spec/automated/map_spec.lua
@@ -1,4 +1,5 @@
 local map = require('scnvim.map').map
+local map_expr = require('scnvim.map').map_expr
 
 describe('map', function()
   it('validates input strings', function()
@@ -41,8 +42,17 @@ describe('map', function()
 
   it('sets a default description', function()
     local ret = map('editor.send_line', 'n')
-    assert.are.equal('scnvim keymap', ret.options.desc)
+    assert.are.equal('scnvim: editor.send_line', ret.options.desc)
     ret = map('editor.send_line', 'n', { desc = 'custom desc' })
+    assert.are.equal('custom desc', ret.options.desc)
+  end)
+end)
+
+describe('map_expr', function()
+  it('sets a default description', function()
+    local ret = map_expr('s.boot', 'n')
+    assert.are.equal('sclang: s.boot', ret.options.desc)
+    ret = map_expr('s.boot', 'n', { desc = 'custom desc' })
     assert.are.equal('custom desc', ret.options.desc)
   end)
 end)


### PR DESCRIPTION
Add default descriptions for keymaps when not specified in keymap configuration:

- `map()`
- `map_expr()`