### PR TITLE
macos bugfix: allow .app in subfolder

### DIFF
--- a/lua/scnvim/sclang.lua
+++ b/lua/scnvim/sclang.lua
@@ -86,7 +86,7 @@ function M.find_sclang_executable()
     local locations = { '/Applications', '/Applications/SuperCollider' }
     for _, loc in ipairs(locations) do
       local app_path = string.format('%s/%s', loc, app)
-      if vim.fn.executable(app_path) then
+      if vim.fn.executable(app_path) ~= 0 then
         return app_path
       end
     end


### PR DESCRIPTION
All paths in the locations array were not considered because the if test always returned true (i.e. the SuperCollider.app had to sit in /Applications). The test should be ~= 0 and thn SuperCollider.app can live inside the subfolder /Applications/SuperCollider.

ref: https://github.com/davidgranstrom/scnvim/issues/200

macOS Mojave, SC 3.13.0, nvim v0.9.5