### PR TITLE
fix for method documentation search

### DIFF
--- a/lua/scnvim/help.lua
+++ b/lua/scnvim/help.lua
@@ -115,7 +115,7 @@ local function open_from_quickfix(index)
     local uri = vim.fn.bufname(item.bufnr)
     local subject = vim.fn.fnamemodify(uri, ':t:r')
     if uv.fs_stat(uri) then
-      M.on_open(nil, uri, subject, item.text)
+      M.on_open(nil, uri, item.text)
     else
       render_help_file(subject, function(result)
         M.on_open(nil, result, item.text)

--- a/lua/scnvim/help.lua
+++ b/lua/scnvim/help.lua
@@ -112,8 +112,7 @@ local function open_from_quickfix(index)
   local item = list[index]
   if item then
     local uri = vim.fn.bufname(item.bufnr)
-    local isWindows = (vim.fn.has 'win32' == 1) and not vim.env.MSYSTEM
-    if isWindows then
+    if _path.get_system() == 'windows' then
       uri = uri:gsub('\\', '/')
     end
     local cmd = string.format('SCNvim.getFileNameFromUri("%s")', uri)


### PR DESCRIPTION
When searching for documentation on a method, the regex doesn't find cases where the line starts with the class name and not just the method name. Also Windows path names are broken coming out of the quickfix window.

This PR should hopefully provide a fix. I added a check for whether Neovim is running on Windows before messing with backslashes, so the path fix shouldn't affect anything on Mac or Linux. Let me know if you need me to split this into a separate commit, I thought I'd just sneak this in since it's just a tiny change.

When you get a chance, can you check this and let me know if anything needs to be cleaned up? I restructured the on_open method and quickfix logic a little so the regex would be easier to parse. I don't think this will break anything, but let me know if I'm missing something and there's a better way to do it. Thanks!