### PR TITLE
Stdout empty lines in post window

### DIFF
--- a/lua/scnvim/sclang.lua
+++ b/lua/scnvim/sclang.lua
@@ -27,11 +27,12 @@ local on_stdout = function()
       local str = table.concat(stack, '')
       local got_line = vim.endswith(str, '\n')
       if got_line then
-        local lines = vim.gsplit(str, '\n')
-        for line in lines do
-          if line ~= '' then
-            M.on_output(line)
-          end
+        local lines = vim.split(str, '\n')
+        if #lines > 0 and lines[#lines] == "" then
+          table.remove(lines)
+        end
+        for _, line in pairs(lines) do
+          M.on_output(line)
         end
         stack = { '' }
       end

--- a/lua/scnvim/sclang.lua
+++ b/lua/scnvim/sclang.lua
@@ -28,7 +28,7 @@ local on_stdout = function()
       local got_line = vim.endswith(str, '\n')
       if got_line then
         local lines = vim.split(str, '\n')
-        if #lines > 0 and lines[#lines] == "" then
+        if #lines > 0 and lines[#lines] == '' then
           table.remove(lines)
         end
         for _, line in pairs(lines) do


### PR DESCRIPTION
This is a little fix that allows posting empty lines in the post window, so that stdout is properly reflected. 
Hope I didn't miss some edge cases, but it seems to work well ! I guess the reason why it was simply discarded was to avoid duplicated empty lines ? If so this solution avoid that :)
