### PR TITLE
Document.sc: support string.openDocument

### DIFF
--- a/scide_scnvim/Classes/Document.sc
+++ b/scide_scnvim/Classes/Document.sc
@@ -31,4 +31,10 @@ Document {
         var path = this.path;
         ^path !? { path.dirname }
     }
+
+    // needed for string.openDocument
+    *implementationClass { ^this }
+    *open { |path|
+        SCNvim.luaeval("vim.cmd'edit %'".format(path))
+    }
 }


### PR DESCRIPTION
Adds `*implementationClass` and `*open` to `Document`.
These are called by `HelpBrowser()` when clicking a link.
Without this pr, scnvim shows and error like "DoesNotUnderstandError: .implementationClass".

I let vim open a Document by calling `luaeval` with `"vim.cmd'edit %'".format(path)`.
