### PR TITLE
postwin: pcall nvim_win_close to ignore errors

### DIFF
--- a/lua/scnvim/postwin.lua
+++ b/lua/scnvim/postwin.lua
@@ -164,7 +164,8 @@ end
 function M.close()
   if M.is_open() then
     save_last_size()
-    api.nvim_win_close(M.win, false)
+    -- This call can fail if its the last window
+    pcall(api.nvim_win_close, M.win, true)
     M.win = nil
   end
 end


### PR DESCRIPTION
I've been in situation when the postwin is already closed and I get an error when trying to close it again, saying that it can't be closed. In this PR I wrap `nvim_win_close` in `pcall`, so that errors are ignored.

If anyone is curious about my actual use case, I have a function to move postwin from side to bottom:
```lua
local postwin = require 'scnvim.postwin'
local cfg = require 'scnvim.config'
cfg.postwin.horizontal = not cfg.postwin.horizontal
if postwin.is_open() then
    postwin.close()
end
postwin.open()
```
And this errors if the postwin is already closed.

