### PR TITLE
Update README.md: Note to mac users regarding startup file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,23 @@ if (\SCNvim.asClass.notNil) {
   Server.program = (Platform.resourceDir +/+ "scsynth.exe").quote;
 }
 ```
+### Note to Mac users
+sclang will set its `Platform.userConfigDir` to XDG_CONFIG_HOME (most likely `/Users/USERNAME/.config`) if it exists, 
+and only if it does not exist, the mac `/Users/USERNAME/Library/Application Support` directory will be used.
+This means that the path to the startup and config files will likely be different in scnvim from that in the
+regular superCollider IDE. 
+
+While the path to the config file can be specified via args to sclang, e.g.:
+```lua
+local scnvim = require('scnvim')
+scnvim.setup({
+  sclang = {
+    cmd = "/Applications/SuperCollider.app/Contents/MacOS/sclang",
+    args = { "-l", "/Users/USERNAME/Library/Application Support/SuperCollider/sclang_conf.yaml" }
+  },
+})
+```
+the same appears not to be possible for the startup file and sclang's `userConfigDir` in general.
 
 ## License
 


### PR DESCRIPTION
Regarding sclangs `Platform.userConfigDir` and startup file. 

contents should be self-explanatory...

This wasn't terribly obvious to me, because once you figure out that you can set a config file via argument to sclang, you can then use that to make sclang find all the extensions you use... That leaves only one component of the `Platform.userConfigDir` whose path can't be manually set: the startup file... and it seems it _can't_ be set, or only after startup, which sort of defeats the purpose. 

I had to do some sleuthing in sc's source (common/SC_Filesystem_macos.cpp) to figure this out, so I thought I might add a note here. It's technically not a scnvim issue but a sc one, but it might help some folks make the switch. And a doc change is quicker than messing with actual code.

(otoh, if there _is_ actually some reasonably elegant way to set the config _directory_ path for sclang, I'd certainly like to know about it... but again, that's a sc issue.)