### PR TITLE
fix(SCNvimDocEntry): JSON generation bug fixes

### DIFF
--- a/scide_scnvim/Classes/SCNvimDoc/SCNvimDoc.sc
+++ b/scide_scnvim/Classes/SCNvimDoc/SCNvimDoc.sc
@@ -225,61 +225,84 @@ SCNvimDocEntry : SCDocEntry {
 	}
 
 	// overriden to output valid json
-	prJSONString {|stream, key, x|
+	prJSONString {|depth=0, stream, key, x, lastItem|
+		var delimiter = if (lastItem.notNil and: { lastItem }, "", ",");
+		var indent = "";
 		if (x.isNil) { x = "" };
 		x = x.escapeChar(92.asAscii); // backslash
 		x = x.escapeChar(34.asAscii); // double quote
-		stream << "\"" << key << "\": \"" << x << "\",\n";
+
+		if (depth > 0) {
+			depth.do {
+				indent = indent ++ "\t";
+			}
+		};
+
+		stream << indent << "\"" << key << "\": \"" << x << "\"%\n".format(delimiter);
 	}
 
 	// overriden to output valid json
-	prJSONList {|stream, key, v, lastItem|
-		var delimiter = if(lastItem.notNil and:{lastItem}, "", ",");
+	prJSONList {|depth=0, stream, key, v, lastItem|
+		var delimiter = if (lastItem.notNil and: { lastItem }, "", ",");
+		var indent = "";
 		if (v.isNil) { v = "" };
-		stream << "\"" << key << "\": [ " << v.collect{|x|"\""++x.escapeChar(34.asAscii)++"\""}.join(",") << " ]%\n".format(delimiter);
+
+		if (depth > 0) {
+			depth.do {
+				indent = indent ++ "\t";
+			}
+		};
+
+		stream << indent << "\"" << key << "\": [" << v.collect{ |x| "\"" ++ x.escapeChar(34.asAscii) ++ "\"" }.join(", ") << "]%\n".format(delimiter);
 	}
 
 	toJSON {|stream, lastItem|
-		var delimiter = if(lastItem.notNil and:{lastItem}, "", ",");
-		var inheritance = [];
-		var numItems;
+		var delimiter = if (lastItem.notNil and: { lastItem }, "", ",");
+		var inheritance = Array.fill(3, nil);
         var keys;
+		var lastKey = 0;
 
 		stream << "\"" << path.escapeChar(34.asAscii) << "\": {\n";
 
-		this.prJSONString(stream, "title", title);
-		this.prJSONString(stream, "path", path);
-		this.prJSONString(stream, "summary", summary);
-		this.prJSONString(stream, "installed", if(isExtension,"extension","standard")); //FIXME: also 'missing'.. better to have separate extension and missing booleans..
-		this.prJSONString(stream, "categories", if(categories.notNil) {categories.join(", ")} {""}); // FIXME: export list instead
-		this.prJSONList(stream, "keywords", keywords);
-		this.prJSONList(stream, "related", related);
+		this.prJSONString(1, stream, "title", title);
+		this.prJSONString(1, stream, "path", path);
+		this.prJSONString(1, stream, "summary", summary);
+		this.prJSONString(1, stream, "installed", if(isExtension,"extension","standard")); //FIXME: also 'missing'.. better to have separate extension and missing booleans..
+		this.prJSONString(1, stream, "categories", if(categories.notNil) {categories.join(", ")} {""}); // FIXME: export list instead
 
-		this.prJSONList(stream, "methods", this.makeMethodList, klass.isNil);
+		this.prJSONList(1, stream, "keywords", keywords);
+		this.prJSONList(1, stream, "related", related);
+		this.prJSONList(1, stream, "methods", this.makeMethodList, klass.isNil and: {oldHelp.isNil});
 
 		if (oldHelp.notNil) {
-			this.prJSONString(stream, "oldhelp", oldHelp);
+			this.prJSONString(1, stream, "oldhelp", oldHelp, klass.isNil);
 		};
 
 		if (klass.notNil) {
 			keys = #[ "superclasses", "subclasses", "implementor" ];
 			klass.superclasses !? {
-				inheritance = inheritance.add(klass.superclasses.collect {|c|
+				inheritance.put(0, klass.superclasses.collect {|c|
 					c.name.asString
 				});
 			};
 			klass.subclasses !? {
-				inheritance = inheritance.add(klass.subclasses.collect {|c|
+				inheritance.put(1, klass.subclasses.collect {|c|
 					c.name.asString
 				});
+				lastKey = 1;
 			};
 			implKlass !? {
-				inheritance = inheritance.add(implKlass.name.asString);
+				inheritance.put(2, implKlass.name.asString);
+				lastKey = 2;
 			};
 
-			numItems = inheritance.size - 1;
 			inheritance.do {|item, i|
-				this.prJSONList(stream, keys[i], item, i >= numItems);
+				if (item.notNil && item.isKindOf(String)) {
+					this.prJSONString(1, stream, keys[i], item, i == lastKey);
+				};
+				if (item.notNil && item.isKindOf(Array)) {
+					this.prJSONList(1, stream, keys[i], item, i == lastKey);
+				};
 			};
 		};
 

--- a/scide_scnvim/Classes/SCNvimDoc/SCNvimDoc.sc
+++ b/scide_scnvim/Classes/SCNvimDoc/SCNvimDoc.sc
@@ -1,15 +1,15 @@
 SCNvimDoc : SCDoc {
 	*exportDocMapJson {|path|
-        var f, numItems;
-        f = File.open(path,"w");
-        numItems = this.documents.size - 1;
-        f << "{\n";
-        this.documents.do {|doc, i|
-            doc.toJSON(f, i >= numItems);
-        };
-        f << "}\n";
-        f.close;
-    }
+		var f, numItems;
+		f = File.open(path,"w");
+		numItems = this.documents.size - 1;
+		f << "{\n";
+		this.documents.do {|doc, i|
+		    doc.toJSON(f, i >= numItems);
+		};
+		f << "}\n";
+		f.close;
+	}
 
 	*parseFileMetaData {|dir,path|
 		var fullPath = dir +/+ path;
@@ -28,7 +28,7 @@ SCNvimDoc : SCDoc {
 		^entry;
 	}
 
- 	*indexAllDocuments { |clearCache=false|
+	*indexAllDocuments { |clearCache=false|
 		var now = Main.elapsedTime;
 		var key, doc;
 		var nonHelpFiles;
@@ -115,94 +115,93 @@ SCNvimDoc : SCDoc {
 		};
 
 		if(str.last == $_) { str = str.drop(-1) };
-        ^str;
+		^str;
 	}
 
-    *prepareHelpForURL {|url|
-        var path, targetBasePath, pathIsCaseInsensitive;
-        var subtarget, src, c, cmd, doc, destExist, destMtime;
-        var verpath = this.helpTargetDir +/+ "version";
-        path = url.asLocalPath;
+	*prepareHelpForURL {|url|
+		var path, targetBasePath, pathIsCaseInsensitive;
+		var subtarget, src, c, cmd, doc, destExist, destMtime;
+		var verpath = this.helpTargetDir +/+ "version";
+		path = url.asLocalPath;
 
-        // detect old helpfiles and wrap them in OldHelpWrapper
-        if(url.scheme == "sc") { ^URI(SCNvimDoc.findHelpFile(path)); };
+		// detect old helpfiles and wrap them in OldHelpWrapper
+		if(url.scheme == "sc") { ^URI(SCNvimDoc.findHelpFile(path)); };
 
-        // just pass through remote url's
-        if(url.scheme != "file") {^url};
+		// just pass through remote url's
+		if(url.scheme != "file") {^url};
 
-        targetBasePath = SCDoc.helpTargetDir;
-        if (thisProcess.platform.name === \windows)
-        { targetBasePath = targetBasePath.replace("/","\\") };
-        pathIsCaseInsensitive = thisProcess.platform.name === \windows;
+		targetBasePath = SCDoc.helpTargetDir;
+		if (thisProcess.platform.name === \windows)
+		{ targetBasePath = targetBasePath.replace("/","\\") };
+		pathIsCaseInsensitive = thisProcess.platform.name === \windows;
 
-        // detect old helpfiles and wrap them in OldHelpWrapper
-        if(
-            /*
-            // this didn't work for quarks due to difference between registered old help path and the quarks symlink in Extensions.
-            // we could use File.realpath(path) below but that would double the execution time,
-            // so let's just assume any local file outside helpTargetDir is an old helpfile.
-            block{|break|
-                Help.do {|key, path|
-                    if(url.endsWith(path)) {
-                        break.value(true)
-                    }
-                }; false
-            }*/
-            compare(
-                path [..(targetBasePath.size-1)],
-                targetBasePath,
-                pathIsCaseInsensitive
-            ) != 0
-        ) {
-            ^SCDoc.getOldWrapUrl(url)
-        };
+		// detect old helpfiles and wrap them in OldHelpWrapper
+		if(
+		/*
+		// this didn't work for quarks due to difference between registered old help path and the quarks symlink in Extensions.
+		// we could use File.realpath(path) below but that would double the execution time,
+		// so let's just assume any local file outside helpTargetDir is an old helpfile.
+		block{|break|
+		Help.do {|key, path|
+			if(url.endsWith(path)) {
+			break.value(true)
+			}
+		}; false
+		}*/
+		compare(
+			path [..(targetBasePath.size-1)],
+			targetBasePath,
+			pathIsCaseInsensitive
+		) != 0
+		) {
+		^SCDoc.getOldWrapUrl(url)
+		};
 
-        if(destExist = File.exists(path))
-        {
-            destMtime = File.mtime(path);
-        };
+		if(destExist = File.exists(path))
+		{
+		destMtime = File.mtime(path);
+		};
 
-        if(path.endsWith(".html.scnvim")) {
-            subtarget = path.drop(this.helpTargetDir.size+1).drop(-12).replace("\\","/");
-            doc = this.documents[subtarget];
-            doc !? {
-                if(doc.isUndocumentedClass) {
-                    if(doc.mtime == 0) {
-                        this.renderUndocClass(doc);
-                        doc.mtime = 1;
-                    };
-                    ^url;
-                };
-                if(File.mtime(doc.fullPath)>doc.mtime) { // src changed after indexing
-                    this.postMsg("% changed, re-indexing documents".format(doc.path),2);
-                    this.indexAllDocuments;
-                    ^this.prepareHelpForURL(url);
-                };
-                if(destExist.not
-                    or: {doc.mtime>destMtime}
-                    or: {doc.additions.detect {|f| File.mtime(f)>destMtime}.notNil}
-                    or: {File.mtime(this.helpTargetDir +/+ "scdoc_version")>destMtime}
-                    or: {doc.klass.notNil and: {File.mtime(doc.klass.filenameSymbol.asString)>destMtime}}
-                ) {
-                    this.parseAndRender(doc);
-                };
-                ^url;
-            };
-        };
+		if(path.endsWith(".html.scnvim")) {
+		subtarget = path.drop(this.helpTargetDir.size+1).drop(-12).replace("\\","/");
+		doc = this.documents[subtarget];
+		doc !? {
+			if(doc.isUndocumentedClass) {
+				if(doc.mtime == 0) {
+				this.renderUndocClass(doc);
+				doc.mtime = 1;
+				};
+				^url;
+			};
+			if(File.mtime(doc.fullPath)>doc.mtime) { // src changed after indexing
+				this.postMsg("% changed, re-indexing documents".format(doc.path),2);
+				this.indexAllDocuments;
+				^this.prepareHelpForURL(url);
+			};
+			if(destExist.not
+				or: {doc.mtime>destMtime}
+				or: {doc.additions.detect {|f| File.mtime(f)>destMtime}.notNil}
+				or: {File.mtime(this.helpTargetDir +/+ "scdoc_version")>destMtime}
+				or: {doc.klass.notNil and: {File.mtime(doc.klass.filenameSymbol.asString)>destMtime}}
+			) {
+				this.parseAndRender(doc);
+			};
+			^url;
+		};
+		};
 
-        if(destExist) {
-            ^url;
-        };
+		if(destExist) {
+		^url;
+		};
 
-        warn("SCDoc: Broken link:" + url.asString);
-        ^nil;
-    }
-
+		warn("SCDoc: Broken link:" + url.asString);
+		^nil;
+	}
 }
 
 SCNvimDocEntry : SCDocEntry {
 	destPath {
-        ^SCDoc.helpTargetDir +/+ path ++ ".html.scnvim";
+		^SCDoc.helpTargetDir +/+ path ++ ".html.scnvim";
 	}
 
 	makeMethodList {


### PR DESCRIPTION
* the inheritance array in `toJSON` could be malformed if the class inheritance hierarchy is incomplete. For example the Object class has subclasses but no superclass, in that case the `superclasses` property would incorrectly represent `subclasses`.

* The method didn't handle the implKlass case where the value would be a string, so we switch on the value type.

* add `lastItem` argument to method `prJSONString` to get valid json

* add `depth` argument to methods `prJSONString` `prJSONList` to get better formatting.

* fix last item conditions for "methods" and "oldhelp" parsing.

patch(SCNvimDoc): retab

* there was a mix of tabs and spaces, only tabs now