### PR TITLE
feat(help): add option to open documentation in a new tab

### DIFF
--- a/doc/SCNvim.txt
+++ b/doc/SCNvim.txt
@@ -31,7 +31,7 @@ implementation, for example the code for indent and syntax highlighting.
 SETUP                                                             *scnvim-setup*
 
 Enable the plugin by calling the setup function in your *init.lua*
->
+>lua
   local scnvim = require('scnvim')
   scnvim.setup()
 <
@@ -46,7 +46,7 @@ KEYMAPS                                                         *scnvim-keymaps*
 No keymaps are defined by default. Use the `scnvim.setup` function to set
 your mappings. The *keywordprg* option is set by scnvim, use `K` to open
 documentation for the word under the cursor.
->
+>lua
   local map = scnvim.map
   scnvim.setup {
     keymaps = {
@@ -81,7 +81,7 @@ The following modules can be used to create a keymap from a string:
 * `signature`
 
 String example~
->
+>lua
   ['<CR>'] = scnvim.map('postwin.toggle')
 <
 This will create a keymap for `<CR>` for the `toggle` function from the
@@ -94,12 +94,12 @@ Function example~
 
 If the `map` helper receives a function it will execute that function when
 pressing the key.
->
+>lua
   ['<leader>st'] = scnvim.map(scnvim.start)
 <
 Here we're using the `scnvim.start` function. But its also possible to map
 arbitrary functions.
->
+>lua
   ['<F1>'] = scnvim.map(function()
     vim.cmd('SCNvimGenerateAssets')
   end)
@@ -107,7 +107,7 @@ arbitrary functions.
 Map expressions~
 
 The `map_expr` helper let's you map SuperCollider code.
->
+>lua
   local map_expr = scnvim.map_expr
   ['<F2>'] = map_expr('s.meter')
 <
@@ -142,7 +142,7 @@ and display the result inside nvim. In order to do so, the scnvim help system
 needs a program to convert HTML help files into plain text e.g. `pandoc[1]`
 
 Set the path to your converter program in the config passed to `scnvim.setup`
->
+>lua
   scnvim.setup{
     documentation = {
       cmd = '/opt/homebrew/bin/pandoc',
@@ -150,14 +150,14 @@ Set the path to your converter program in the config passed to `scnvim.setup`
   }
 <
 
-Customization~
+Customization ~
 
 The help system is configured to use `pandoc` by default. To use another
 program you will also need to supply the command line arguments needed to
 perform the HTML to plain text conversion. The example below is for the
 `html2text` program. `$1` is a placeholder for the *input file* and `$2` is a
 placeholder for the *output file*, these are replaced automatically.
->
+>lua
   scnvim.setup{
     documentation = {
       cmd = '/usr/local/bin/html2text',
@@ -190,7 +190,7 @@ You can also view an up-to-date HTML version of the documentation by visiting
 this link: https://davidgranstrom.github.io/scnvim/modules/scnvim.config.html
 
 Example configuration~
->
+>lua
   scnvim.setup {
     mapping = {
       ['<M-e>'] = scnvim.map.send_line({'i', 'n'}),

--- a/lua/scnvim/config.lua
+++ b/lua/scnvim/config.lua
@@ -41,6 +41,7 @@ local default = {
   --- string $1 will be replaced with the input file path and $2 will be replaced
   --- with the output file path.
   ---
+  ---@field tab (default: false) If true open the help window in a new tab
   ---@field horizontal (default: true) Open the help window as a horizontal split
   ---@field direction (default: 'top') Direction of the split: 'top', 'right', 'bot', 'left'
   ---@field keymaps (default: true) If true apply user keymaps to the help
@@ -48,6 +49,7 @@ local default = {
   documentation = {
     cmd = nil,
     args = { '$1', '--from', 'html', '--to', 'plain', '-o', '$2' },
+    tab = false,
     horizontal = true,
     direction = 'top',
     keymaps = true,

--- a/lua/scnvim/help.lua
+++ b/lua/scnvim/help.lua
@@ -41,18 +41,26 @@ M.on_open = action.new(function(err, uri, pattern)
   if is_open then
     vim.cmd(expr)
   else
-    local horizontal = config.documentation.horizontal
-    local direction = config.documentation.direction
-    if direction == 'top' or direction == 'left' then
-      direction = 'leftabove'
-    elseif direction == 'right' or direction == 'bot' then
-      direction = 'rightbelow'
+    if config.documentation.tab then
+      local win_cmd = string.format('tabnew | %s', expr)
+      vim.cmd(win_cmd)
     else
-      error '[scnvim] invalid config.documentation.direction'
+      local horizontal = config.documentation.horizontal
+      local direction = config.documentation.direction
+      if direction == 'top' or direction == 'left' then
+        direction = 'leftabove'
+      elseif direction == 'right' or direction == 'bot' then
+        direction = 'rightbelow'
+      else
+        error '[scnvim] invalid config.documentation.direction'
+      end
+      local win_cmd = string.format('%s %s | %s', direction, horizontal and 'split' or 'vsplit', expr)
+      vim.cmd(win_cmd)
     end
-    local win_cmd = string.format('%s %s | %s', direction, horizontal and 'split' or 'vsplit', expr)
-    vim.cmd(win_cmd)
     win_id = vim.fn.win_getid()
+    vim.opt_local.number = false
+    vim.opt_local.relativenumber = false
+    vim.opt_local.wrap = false
   end
 end)
 


### PR DESCRIPTION
I'm really liking this way of interacting with the help system, so maybe it is worth adding ? 

* unset 'numbers' 'relativenumbers' 'wrap'

patch(doc): lua highlights for code blocks + fix typo
