### PR TITLE
fix(doc): prevent docmap crash

### DIFF
--- a/scide_scnvim/Classes/SCNvimDoc/SCNvimDoc.sc
+++ b/scide_scnvim/Classes/SCNvimDoc/SCNvimDoc.sc
@@ -244,7 +244,6 @@ SCNvimDocEntry : SCDocEntry {
 		var delimiter = if(lastItem.notNil and:{lastItem}, "", ",");
 		var inheritance = [];
 		var numItems;
-        var keys;
 
 		stream << "\"" << path.escapeChar(34.asAscii) << "\": {\n";
 
@@ -263,24 +262,25 @@ SCNvimDocEntry : SCDocEntry {
 		};
 
 		if (klass.notNil) {
-			keys = #[ "superclasses", "subclasses", "implementor" ];
+			// keep each key paired with its value so a missing entry can't
+			// shift the labels, and always pass an array to prJSONList
 			klass.superclasses !? {
-				inheritance = inheritance.add(klass.superclasses.collect {|c|
+				inheritance = inheritance.add(["superclasses", klass.superclasses.collect {|c|
 					c.name.asString
-				});
+				}]);
 			};
 			klass.subclasses !? {
-				inheritance = inheritance.add(klass.subclasses.collect {|c|
+				inheritance = inheritance.add(["subclasses", klass.subclasses.collect {|c|
 					c.name.asString
-				});
+				}]);
 			};
 			implKlass !? {
-				inheritance = inheritance.add(implKlass.name.asString);
+				inheritance = inheritance.add(["implementor", [implKlass.name.asString]]);
 			};
 
 			numItems = inheritance.size - 1;
-			inheritance.do {|item, i|
-				this.prJSONList(stream, keys[i], item, i >= numItems);
+			inheritance.do {|pair, i|
+				this.prJSONList(stream, pair[0], pair[1], i >= numItems);
 			};
 		};
 


### PR DESCRIPTION
```
➜ nvim --version
NVIM v0.12.2
Build type: Release
LuaJIT 2.1.1774896198
```

I met a weird issue with :SCNvimGenerateAssets and opening helpfiles.
The first time I hit `K` (SCNvimHelp) I would get:

```
SCDoc: Indexing help-files...
ERROR: Message 'escapeChar' not understood.
RECEIVER:
   Character 68 'D'
ARGS:
   Character 34 '"'
KEYWORD ARGUMENTS:
CALL STACK:
	DoesNotUnderstandError:reportError
		arg this = <instance of DoesNotUnderstandError>
	Nil:handleError
		arg this = nil
		arg error = <instance of DoesNotUnderstandError>
	Thread:handleError
		arg this = <instance of Thread>
		arg error = <instance of DoesNotUnderstandError>
	Object:throw
		arg this = <instance of DoesNotUnderstandError>
	Object:doesNotUnderstand
		arg this = $D
		arg selector = 'escapeChar'
		arg args = [*1]
		arg kwargs = [*0]
	< closed FunctionDef >
		arg x = $D
	< FunctionDef in Method Collection:collectAs >
		arg elem = $D
		arg i = 0
	ArrayedCollection:do
		arg this = "Document"
		arg function = <instance of Function>
		var i = 0
	Collection:collectAs
		arg this = "Document"
		arg function = <instance of Function>
		arg class = <instance of Meta_String>
		var res = ""
	SCNvimDocEntry:prJSONList
		arg this = <instance of SCNvimDocEntry>
		arg stream = <instance of File>
		arg key = "subclasses"
		arg v = "Document"
		arg lastItem = true
		var delimiter = ""
	ArrayedCollection:do
		arg this = [*2]
		arg function = <instance of Function>
		var i = 1
	SCNvimDocEntry:toJSON
		arg this = <instance of SCNvimDocEntry>
		arg stream = <instance of File>
		arg lastItem = false
		var delimiter = ","
		var inheritance = [*2]
		var numItems = 1
		var keys = [*3]
	< FunctionDef in Method Dictionary:do >
		arg key = "Classes/Document"
		arg value = <instance of SCNvimDocEntry>
		arg i = 2710
	Dictionary:keysValuesArrayDo
		arg this = <instance of Dictionary>
		arg argArray = [*16384]
		arg function = <instance of Function>
		var i = 16188
		var j = 2711
		var key = nil
		var val = nil
		var arraySize = nil
	Dictionary:keysValuesDo
		arg this = <instance of Dictionary>
		arg function = <instance of Function>
	Dictionary:do
		arg this = <instance of Dictionary>
		arg function = <instance of Function>
...
^^ ERROR: Message 'escapeChar' not understood.
RECEIVER: D
```

SCNvimDocEntry.toJSON created `inheritance` by appending superclasses and subclasses as arrays. But the implementor (implKlass) as a string.
    
`prJSONList` does `v.collect {|x| "\"" ++ x.escapeChar($") ++ "\""}`. Given the bare implementor String, `collect` iterates the string's characters and calls escapeChar on them, throwing `DoesNotUnderstand: 'escapeChar'` and aborting/crashing the entire docmap export. WHich leaves docmap.json broken.

This is fixed by pairing each key with its value and wrap the implementor name in an array, so prJSONList always receives a list.
