### PR TITLE
Handle help look up on a non-existent class without crashing

### DIFF
--- a/lua/scnvim/help.lua
+++ b/lua/scnvim/help.lua
@@ -82,7 +82,7 @@ local function render_help_file(subject, on_done)
   local cmd = string.format('SCNvim.getHelpUri("%s")', subject)
   sclang.eval(cmd, function(input_path)
     if not input_path then
-      utils.print(string.format('The class %s does not exist', subject))
+      utils.print(string.format('The class %s does not exist', subject), 'WarningMsg')
       return
     end
     local basename = input_path:gsub('%.html%.scnvim', '')
@@ -134,7 +134,7 @@ end
 ---@param results Table with results
 M.on_select = action.new(function(err, results)
   if err then
-    print(err)
+    utils.print(err, 'WarningMsg')
     return
   end
   local id = api.nvim_create_augroup('scnvim_qf_conceal', { clear = true })

--- a/lua/scnvim/help.lua
+++ b/lua/scnvim/help.lua
@@ -81,6 +81,10 @@ end
 local function render_help_file(subject, on_done)
   local cmd = string.format('SCNvim.getHelpUri("%s")', subject)
   sclang.eval(cmd, function(input_path)
+    if not input_path then
+      utils.print(string.format('The class %s does not exist', subject))
+      return
+    end
     local basename = input_path:gsub('%.html%.scnvim', '')
     local output_path = basename .. '.txt'
     local args = get_render_args(input_path, output_path)


### PR DESCRIPTION
Requesting help for a subject (class) that has no help file currently throws a Lua error for classes. It not really a problem. But it doesn't look fantastic.

Chachachachaaanges:

1. Guard the nil URI in render_help_file:
```
sclang.eval(cmd, function(input_path)
  if not input_path then
    utils.print(string.format('The class %s does not exist', subject))
    return
  end
```

2. Unify styling: M.on_select previously used plain `print(err)` switched to `utils.print(err)` so the method "No results" message matches the new class message.

Both of these are routine "not found" outcomes, not errors, so routing them through utils.print (red ErrorMsg + persisted in :messages) may be heavier than warranted — it adds an entry to the message history on every miss. Would you/we prefer these informational misses go to the SuperCollider post window instead?_(keeping nvim's message area / :messages uncluttered)_

Ps. please note that this cannot really be tested without #269
If the doc-fix branch changes is not included the lua error explodes and we never see the new nice unified styling        8-)

Neeevertheless the important thing here is to catch the non-existing subject/class look up and prevent the lua crash.